### PR TITLE
[CLOUD-2545] Added clustering and draining

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -43,6 +43,9 @@ envs:
     - name: SCRIPT_DEBUG
       description: If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
       example: "true"
+    - name: AMQ_DATA_DIR
+      description: Allows you to set the data directory to be on persistent storage.
+      example: /opt/amq/data      
     - name: AMQ_CLUSTERED
       description: Enable Clustering
       example: "true"
@@ -136,6 +139,7 @@ run:
       user: 185
       cmd:
           - "/opt/amq/bin/launch.sh"
+          - "start"                
 osbs:
       repository:
             name: containers/amq-7-broker

--- a/image.yaml
+++ b/image.yaml
@@ -95,11 +95,15 @@ ports:
     - value: 5672
     - value: 5671
     - value: 1883
-    - value: 8181
+    - value: 8161
+    - value: 9876
     - value: 61613
     - value: 61612
     - value: 61616
     - value: 61617
+    - value: 7800
+    - value: 8888
+    
 modules:
       repositories:
           - name: cct_module
@@ -115,11 +119,11 @@ modules:
           - name: openshift-passwd
           - name: os-logging
           - name: os-amq-permissions
+          - name: os-java-jolokia
           - name: amq.broker71.jolokia.access
           - name: amq.broker71.launch
           - name: amq.broker71.s2i
-          - name: amq.custom.config
-        
+          - name: amq.custom.config   
 packages:
       repositories:
           - jboss-os

--- a/modules/amq-launch/added/drain.sh
+++ b/modules/amq-launch/added/drain.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+export BROKER_IP=`hostname -I | cut -f 1 -d ' '`
+
+instanceDir="${HOME}/${AMQ_NAME}"
+
+ENDPOINT_NAME="${AMQ_NAME}-amq-tcp"
+POD_NAMESPACE=`cat ${AMQ_DATA_DIR"/podnamespace`
+
+endpointsUrl="https://${KUBERNETES_SERVICE_HOST:-kubernetes.default.svc}:${KUBERNETES_SERVICE_PORT:-443}/api/v1/namespaces/${POD_NAMESPACE}/"
+endpointsAuth="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+
+endpointsCode=$(curl -s -o /dev/null -w "%{http_code}" -G -k -H "${endpointsAuth}" ${endpointsUrl})
+if [ $endpointsCode -ne 200 ]; then
+	echo "Can't find endpoints with ips status <${endpointsCode}>" 
+	exit 1
+fi
+
+ENDPOINTS=$(curl -s -X GET -G -k -H "${endpointsAuth}" ${endpointsUrl}"endpoints/${ENDPOINT_NAME}")
+echo $ENDPOINTS
+count=0
+while [ 1 ]; do
+	ip=$(echo $ENDPOINTS | python -c "import sys, json; print json.load(sys.stdin)['subsets'][0]['addresses'][${count}]['ip']")
+	if [ $? -ne 0 ]; then
+		echo "Can't find ip to scale down to tried ${count} ips"
+		exit
+	fi
+
+	echo "got ip ${ip} broker ip is ${BROKER_IP}"
+	if [ "$ip" != "$BROKER_IP" ]; then
+		break
+	fi
+
+	count=$(( count + 1 ))
+done
+
+SCALE_TO_BROKER_IP=$ip
+
+# Add connector to the pod to scale down to
+connector="<connector name=\"scaledownconnector\">tcp:\/\/${SCALE_TO_BROKER_IP}:61616<\/connector>"
+sed -i "/<\/connectors>/ s/.*/${connector}\n&/" ${instanceDir}/etc/broker.xml
+
+# Remove the acceptors
+#sed -i -ne "/<acceptors>/ {p;   " -e ":a; n; /<\/acceptors>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml
+acceptor="<acceptor name=\"artemis\">tcp:\/\/${BROKER_IP}:61616?protocols=CORE<\/acceptor>"
+sed -i -ne "/<acceptors>/ {p; i $acceptor" -e ":a; n; /<\/acceptors>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml
+
+#start the broker and issue the scaledown command to drain the messages.
+${instanceDir}/bin/artemis-service start
+sleep 15
+curl http://${AMQ_USER}:${AMQ_PASSWORD}@${BROKER_IP}:8161/console/jolokia/exec/org.apache.activemq.artemis:broker=%22broker%22/scaleDown/scaledownconnector

--- a/modules/amq-launch/added/drain.sh
+++ b/modules/amq-launch/added/drain.sh
@@ -5,7 +5,6 @@ export BROKER_IP=`hostname -I | cut -f 1 -d ' '`
 instanceDir="${HOME}/${AMQ_NAME}"
 
 ENDPOINT_NAME="${AMQ_NAME}-amq-tcp"
-POD_NAMESPACE=`cat ${AMQ_DATA_DIR"/podnamespace`
 
 endpointsUrl="https://${KUBERNETES_SERVICE_HOST:-kubernetes.default.svc}:${KUBERNETES_SERVICE_PORT:-443}/api/v1/namespaces/${POD_NAMESPACE}/"
 endpointsAuth="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
@@ -33,6 +32,8 @@ while [ 1 ]; do
 
 	count=$(( count + 1 ))
 done
+
+source /opt/amq/bin/launch.sh
 
 SCALE_TO_BROKER_IP=$ip
 

--- a/modules/amq-launch/added/drain.sh
+++ b/modules/amq-launch/added/drain.sh
@@ -50,3 +50,13 @@ sed -i -ne "/<acceptors>/ {p; i $acceptor" -e ":a; n; /<\/acceptors>/ {p; b}; ba
 ${instanceDir}/bin/artemis-service start
 sleep 15
 curl http://${AMQ_USER}:${AMQ_PASSWORD}@${BROKER_IP}:8161/console/jolokia/exec/org.apache.activemq.artemis:broker=%22broker%22/scaleDown/scaledownconnector
+
+tail -n 100 -f broker/log/artemis.log &
+
+ps -C java
+
+while [ $? -eq 0 ]
+do
+	sleep 15;
+	ps -C java;
+done

--- a/modules/amq-launch/added/jgroups-ping.xml
+++ b/modules/amq-launch/added/jgroups-ping.xml
@@ -1,0 +1,55 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:org:jgroups"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+    <TCP bind_port="7800"
+
+         recv_buf_size="${tcp.recv_buf_size:5M}"
+         send_buf_size="${tcp.send_buf_size:5M}"
+         max_bundle_size="64K"
+         max_bundle_timeout="30"
+         use_send_queues="true"
+         sock_conn_timeout="300"
+
+         timer_type="new3"
+         timer.min_threads="4"
+         timer.max_threads="10"
+         timer.keep_alive_time="3000"
+         timer.queue_max_size="500"
+         
+         thread_pool.enabled="true"
+         thread_pool.min_threads="2"
+         thread_pool.max_threads="8"
+         thread_pool.keep_alive_time="5000"
+         thread_pool.queue_enabled="true"
+         thread_pool.queue_max_size="10000"
+         thread_pool.rejection_policy="discard"
+
+         oob_thread_pool.enabled="true"
+         oob_thread_pool.min_threads="1"
+         oob_thread_pool.max_threads="8"
+         oob_thread_pool.keep_alive_time="5000"
+         oob_thread_pool.queue_enabled="false"
+         oob_thread_pool.queue_max_size="100"
+         oob_thread_pool.rejection_policy="discard"/>
+
+<openshift.DNS_PING timeout="3000" serviceName="ping" />
+                         
+    <MERGE3  min_interval="10000"
+             max_interval="30000"/>
+    <FD_SOCK/>
+    <FD timeout="3000" max_tries="3" />
+    <VERIFY_SUSPECT timeout="1500"  />
+	<BARRIER />
+    <pbcast.NAKACK2 use_mcast_xmit="false"
+                   discard_delivered_msgs="true"/>
+    <UNICAST3 />
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+                   max_bytes="4M"/>
+    <pbcast.GMS print_local_addr="true"
+                view_bundling="true"/>
+     <MFC max_credits="2M"
+         min_threshold="0.4"/>
+    <FRAG2 frag_size="60K"  />
+    <!--RSVP resend_interval="2000" timeout="10000"/-->
+    <pbcast.STATE_TRANSFER/>
+</config>

--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -7,6 +7,7 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
 fi
 
+
 export BROKER_IP=`hostname -I | cut -f 1 -d ' '`
 CONFIG_TEMPLATES=/config_templates
 #Set the memory options
@@ -14,6 +15,7 @@ JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 
 #GC Option conflicts with the one already configured.
 JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-XX:+UseParallelOldGC/ /")
+JAVA_OPTS="-Djava.net.preferIPv4Stack=true ${JAVA_OPTS}"
 
 function sslPartial() {
     [ -n "$AMQ_KEYSTORE_TRUSTSTORE_DIR" -o -n "$AMQ_KEYSTORE" -o -n "$AMQ_TRUSTSTORE" -o -n "$AMQ_KEYSTORE_PASSWORD" -o -n "$AMQ_TRUSTSTORE_PASSWORD" ]
@@ -57,57 +59,74 @@ function configureSSL() {
 }
 
 function updateAcceptors() {
-
-    instanceDir=$1	
-    echo "keystorepassword $keyStorePassword"
-    echo "keystore filepath: $keyStorePath"
+	if sslEnabled ; then
+    	instanceDir=$1	
+    	echo "keystorepassword $keyStorePassword"
+    	echo "keystore filepath: $keyStorePath"
 	
-    IFS=',' read -a protocols <<< $(find_env "AMQ_PROTOCOL" "openwire,amqp,stomp,mqtt,hornetq")
-    connectionsAllowed=$(find_env "AMQ_MAX_CONNECTIONS" "1000")
+    	IFS=',' read -a protocols <<< $(find_env "AMQ_TRANSPORTS" "openwire,amqp,stomp,mqtt,hornetq")
+    	connectionsAllowed=$(find_env "AMQ_MAX_CONNECTIONS" "1000")
 
-    if [ "${#protocols[@]}" -ne "0" ]; then
-    acceptors=""
-    for protocol in ${protocols[@]}; do
-      case "${protocol}" in
-        "openwire")
-acceptors="${acceptors}            <acceptor name=\"artemis\">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;connectionsAllowed=${connectionsAllowed}</acceptor>\n"
-          if sslEnabled ; then
-    acceptors="${acceptors}            <acceptor name=\"artemis\">tcp://0.0.0.0:61617?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
-          fi
-          ;;
-        "mqtt")
-acceptors="${acceptors}            <acceptor name=\"mqtt\">tcp://0.0.0.0:1883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true;connectionsAllowed=${connectionsAllowed}</acceptor>\n"
-          if sslEnabled ; then
-acceptors="${acceptors}            <acceptor name=\"mqtt\">tcp://0.0.0.0:8883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
-          fi
-          ;;
-        "amqp")
-acceptors="${acceptors}            <acceptor name=\"amqp\">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300;connectionsAllowed=${connectionsAllowed}</acceptor>\n"      
-          if sslEnabled ; then
-    acceptors="${acceptors}            <acceptor name=\"amqp\">tcp://0.0.0.0:5671?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
-          fi
-          ;;
-        "stomp")
-acceptors="${acceptors}            <acceptor name=\"stomp\">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true;connectionsAllowed=${connectionsAllowed}</acceptor>\n"
-          if sslEnabled ; then
-    acceptors="${acceptors}            <acceptor name=\"stomp\">tcp://0.0.0.0:61612?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
-          fi
-          ;;
-        "hornetq")
-acceptors="${acceptors}            <acceptor name=\"hornetq\">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP;useEpoll=true;connectionsAllowed=${connectionsAllowed}</acceptor>\n"
-          ;;
-      esac
-    done
-    sed -i -ne "/<acceptors>/ {p; i $acceptors" -e ":a; n; /<\/acceptors>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml
+    	if [ "${#protocols[@]}" -ne "0" ]; then
+    		acceptors=""
+    		for protocol in ${protocols[@]}; do
+    		case "${protocol}" in
+        	"openwire")
+				acceptors="${acceptors}            <acceptor name=\"artemis-ssl\">tcp://${ACCEPTOR_IP}:61617?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
+        	;;
+        	"mqtt")
+				acceptors="${acceptors}            <acceptor name=\"mqtt-ssl\">tcp://${ACCEPTOR_IP}:8883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
+        	;;
+        	"amqp")
+    			acceptors="${acceptors}            <acceptor name=\"amqp-ssl\">tcp://${ACCEPTOR_IP}:5671?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
+        	;;
+        	"stomp")
+    			acceptors="${acceptors}            <acceptor name=\"stomp-ssl\">tcp://${ACCEPTOR_IP}:61612?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true;connectionsAllowed=${connectionsAllowed};sslEnabled=true;keyStorePath=${keyStorePath};keyStorePassword=${keyStorePassword}</acceptor>\n"
+        	;;
+    		esac
+    		done
+    	fi
+	safeAcceptors=$(echo "${acceptors}" | sed 's/\//\\\//g')	    	
+	sed -i "/<\/acceptors>/ s/.*/${safeAcceptors}\n&/" ${instanceDir}/etc/broker.xml    
 fi
 }
-      
+
+function modifyDiscovery() {
+    discoverygroup=""
+discoverygroup="${discoverygroup}       <discovery-group name=\"my-discovery-group\">"
+    discoverygroup="${discoverygroup}          <jgroups-file>jgroups-ping.xml</jgroups-file>"
+    discoverygroup="${discoverygroup}          <jgroups-channel>activemq_broadcast_channel</jgroups-channel>"
+    discoverygroup="${discoverygroup}          <refresh-timeout>10000</refresh-timeout>"
+    discoverygroup="${discoverygroup}       </discovery-group>	"
+	sed -i -ne "/<discovery-groups>/ {p; i $discoverygroup" -e ":a; n; /<\/discovery-groups>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml	
+
+    broadcastgroup=""		
+    broadcastgroup="${broadcastgroup}       <broadcast-group name=\"my-broadcast-group\">"
+    broadcastgroup="${broadcastgroup}          <jgroups-file>jgroups-ping.xml</jgroups-file>"
+    broadcastgroup="${broadcastgroup}          <jgroups-channel>activemq_broadcast_channel</jgroups-channel>"
+    broadcastgroup="${broadcastgroup}          <connector-ref>artemis</connector-ref>"
+    broadcastgroup="${broadcastgroup}       </broadcast-group>	"
+	sed -i -ne "/<broadcast-groups>/ {p; i $broadcastgroup" -e ":a; n; /<\/broadcast-groups>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml	
+
+    clusterconnections=""
+    clusterconnections="${clusterconnections}       <cluster-connection name=\"my-cluster\">"
+	clusterconnections="${clusterconnections}          <connector-ref>artemis</connector-ref>"
+    clusterconnections="${clusterconnections}          <retry-interval>500</retry-interval>"
+    clusterconnections="${clusterconnections}          <use-duplicate-detection>true</use-duplicate-detection>"
+    clusterconnections="${clusterconnections}          <message-load-balancing>STRICT</message-load-balancing>"
+    clusterconnections="${clusterconnections}          <max-hops>1</max-hops>"
+    clusterconnections="${clusterconnections}          <discovery-group-ref discovery-group-name=\"my-discovery-group\"/>"
+    clusterconnections="${clusterconnections}       </cluster-connection>	"
+	sed -i -ne "/<cluster-connections>/ {p; i $clusterconnections" -e ":a; n; /<\/cluster-connections>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml							
+}
+
+         
 function configure() {
     instanceDir=$1
     
     export CONTAINER_ID=$HOSTNAME
     if [ ! -d ${instanceDir} -o "$AMQ_RESET_CONFIG" = "true" -o ! -f ${instanceDir}/bin/artemis ]; then
-    AMQ_ARGS="--role $AMQ_ROLE --name $AMQ_NAME --allow-anonymous --http-host $BROKER_IP "
+    	AMQ_ARGS="--role $AMQ_ROLE --name $AMQ_NAME --allow-anonymous --http-host $BROKER_IP --java-options=-Djava.net.preferIPv4Stack=true "
         if [ -n "${AMQ_USER}" -a -n "${AMQ_PASSWORD}" ] ; then
             AMQ_ARGS="--user $AMQ_USER --password $AMQ_PASSWORD $AMQ_ARGS "
         fi
@@ -147,8 +166,10 @@ function configure() {
             if [ "$AMQ_SLAVE" = "true" ]; then
                 AMQ_ARGS="$AMQ_ARGS --slave"
             fi
+            ACCEPTOR_IP=$BROKER_IP
         else
-			AMQ_ARGS="$AMQ_ARGS --host 0.0.0.0"
+        	AMQ_ARGS="$AMQ_ARGS --host 0.0.0.0"
+			ACCEPTOR_IP="0.0.0.0"
         fi
         if [ "$AMQ_RESET_CONFIG" = "true" ]; then
             AMQ_ARGS="$AMQ_ARGS --force"
@@ -161,8 +182,14 @@ function configure() {
         echo "Creating Broker with args $AMQ_ARGS"
 
         $AMQ_HOME/bin/artemis create ${instanceDir} $AMQ_ARGS --java-options "$JAVA_OPTS"
+        if [ "$AMQ_CLUSTERED" = "true" ]; then
+			modifyDiscovery
+		fi
         $AMQ_HOME/bin/configure_jolokia_access.sh ${instanceDir}/etc/jolokia-access.xml
-        updateAcceptors ${instanceDir}
+        if [ "$AMQ_KEYSTORE_TRUSTSTORE_DIR" ]; then
+        	echo "Updating acceptors for SSL"
+        	updateAcceptors ${instanceDir}
+		fi
         $AMQ_HOME/bin/configure_s2i_files.sh ${instanceDir}
         $AMQ_HOME/bin/configure_custom_config.sh ${instanceDir}
 	fi
@@ -173,10 +200,13 @@ function removeWhiteSpace() {
 }
 
 function runServer() {
+	echo ${POD_NAMESPACE} > ${AMQ_DATA_DIR}/podnamespace
+	
 	echo "Configuring Broker"
     instanceDir="${HOME}/${AMQ_NAME}"
 
     configure $instanceDir
+
     echo "Running Broker"
     exec ${instanceDir}/bin/artemis run
 

--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -200,16 +200,16 @@ function removeWhiteSpace() {
 }
 
 function runServer() {
-	echo ${POD_NAMESPACE} > ${AMQ_DATA_DIR}/podnamespace
 	
 	echo "Configuring Broker"
     instanceDir="${HOME}/${AMQ_NAME}"
 
     configure $instanceDir
 
-    echo "Running Broker"
-    exec ${instanceDir}/bin/artemis run
-
+	if [ "$1" = "start" ]; then
+    	echo "Running Broker"
+    	exec ${instanceDir}/bin/artemis run
+    fi
 }
 
-runServer
+runServer $1

--- a/modules/amq-launch/added/readinessProbe.sh
+++ b/modules/amq-launch/added/readinessProbe.sh
@@ -24,9 +24,9 @@ import sys
 
 # calculate the open ports
 try:
-  tcp_file = open("/proc/net/tcp6", "r")
-except IOError:
   tcp_file = open("/proc/net/tcp", "r")
+except IOError:
+  tcp_file = open("/proc/net/tcp6", "r")
 tcp_lines = tcp_file.readlines()
 header = tcp_lines.pop(0)
 tcp_file.close()

--- a/modules/amq-launch/install.sh
+++ b/modules/amq-launch/install.sh
@@ -3,7 +3,24 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
+SOURCES_DIR="/tmp/artifacts"
 
-cp $ADDED_DIR/launch.sh ${ADDED_DIR}/readinessProbe.sh $AMQ_HOME/bin
+# Add OpenShift PING implementation
+VERSION="1.2.1.Final-redhat-1"
+
+DEST=$AMQ_HOME
+
+mkdir -p ${DEST}
+mkdir -p ${DEST}/conf/
+
+cp -p ${SOURCES_DIR}/openshift-ping-common-$VERSION.jar \
+      ${SOURCES_DIR}/openshift-ping-dns-$VERSION.jar \
+    ${DEST}/lib
+	
+cp -p $ADDED_DIR/jgroups-ping.xml \
+	${DEST}/conf/	
+
+cp $ADDED_DIR/launch.sh ${ADDED_DIR}/readinessProbe.sh ${ADDED_DIR}/drain.sh $AMQ_HOME/bin
 chmod 0755 $AMQ_HOME/bin/launch.sh
 chmod 0755 $AMQ_HOME/bin/readinessProbe.sh
+chmod 0755 $AMQ_HOME/bin/drain.sh

--- a/modules/amq-launch/module.yaml
+++ b/modules/amq-launch/module.yaml
@@ -4,3 +4,9 @@ name: amq.broker71.launch
 version: '1.0'
 execute:
     - script: install.sh    
+    
+artifacts:
+- path: openshift-ping-common-1.2.1.Final-redhat-1.jar
+  md5: 7a6db2d84d9c6326363522f97f2d0f05
+- path: openshift-ping-dns-1.2.1.Final-redhat-1.jar
+  md5: fbd94724882e9ad41d1c4db52875b8d4

--- a/templates/amq-broker-71-custom.yaml
+++ b/templates/amq-broker-71-custom.yaml
@@ -143,7 +143,7 @@ objects:
           name: ${APPLICATION_NAME}-amq
           ports:
           - containerPort: 8161
-            name: jolokia
+            name: console-jolokia
             protocol: TCP
           - containerPort: 5672
             name: amqp

--- a/templates/amq-broker-71-persistence.yaml
+++ b/templates/amq-broker-71-persistence.yaml
@@ -142,7 +142,7 @@ objects:
           name: ${APPLICATION_NAME}-amq
           ports:
           - containerPort: 8161
-            name: jolokia
+            name: console-jolokia
             protocol: TCP
           - containerPort: 5672
             name: amqp

--- a/templates/amq-broker-71-ssl.yaml
+++ b/templates/amq-broker-71-ssl.yaml
@@ -216,7 +216,7 @@ objects:
             name: ${APPLICATION_NAME}-amq
             ports:
             - containerPort: 8161
-              name: jolokia
+              name: console-jolokia
               protocol: TCP
             - containerPort: 5672
               name: amqp

--- a/templates/amq-broker-71-statefulset-clustered-drain.yaml
+++ b/templates/amq-broker-71-statefulset-clustered-drain.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: amq-broker-71-basic
+  template: amq-broker-71-persistence-with-clustering
   xpaas: 1.4.12
 message: A new messaging service has been created in your project. It will handle the protocol(s) "${AMQ_PROTOCOL}". The username/password for accessing the service is ${AMQ_USER}/${AMQ_PASSWORD}.
 metadata:
@@ -12,7 +12,7 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: messaging,amq,jboss
     version: 1.4.9
-  name: amq-broker-71-basic
+  name: amq-broker-71-persistence-with-clustering
 objects:
 - apiVersion: v1
   kind: Service
@@ -88,15 +88,68 @@ objects:
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
 - apiVersion: v1
-  kind: DeploymentConfig
+  kind: Service
+  metadata:
+    annotations:
+      description: The JGroups ping port for clustering.
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ping
+  spec:
+    clusterIP: None  
+    ports:
+      - targetPort: 8888
+        port: 8888
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq      
+- apiVersion: apps/v1
+  kind: StatefulSet
   metadata:
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq
+    annotations:
+      statefulsets.kubernetes.io/drainer-pod-template: |
+        {
+          "metadata": {
+            "labels": {
+              "app": "${APPLICATION_NAME}-amq-drainer"
+            }
+          },
+          "spec": {
+            "terminationGracePeriodSeconds": 5,
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "POD_NAMESPACE",
+                    "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  }
+                ]              
+                "image": "172.30.230.48:5000/openshift/amq-broker-71-openshift:1.0@sha256:8370bab1d0cfffbeb66067fa7ad64e883dffe96d3cb0c1ed0e6212ecd9eeb9f2",
+                "name": "${APPLICATION_NAME}-amq",
+                
+                "command": ["/bin/sh", "-c", "echo \"Draining data... this takes 10 seconds!\" ; /opt/amq/bin/drain.sh; sleep 100 ; rm /var/data/test.txt; echo \"Data deleted!\""],               
+                "volumeMounts": [
+                  {
+                    "name": "${APPLICATION_NAME}-amq-pvol",
+                    "mountPath": "${AMQ_DATA_DIR}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
   spec:
-    replicas: 1
+    replicas: ${AMQ_REPLICAS}
     selector:
-      deploymentConfig: ${APPLICATION_NAME}-amq
+      matchLabels:
+        app: ${APPLICATION_NAME}-amq
     strategy:
       rollingParams:
         maxSurge: 0
@@ -106,6 +159,7 @@ objects:
         labels:
           application: ${APPLICATION_NAME}
           deploymentConfig: ${APPLICATION_NAME}-amq
+          app: ${APPLICATION_NAME}-amq
         name: ${APPLICATION_NAME}-amq
       spec:
         containers:
@@ -128,14 +182,27 @@ objects:
             value: ${AMQ_GLOBAL_MAX_SIZE}
           - name: AMQ_QUEUE_MEMORY_LIMIT
             value: ${AMQ_QUEUE_MEMORY_LIMIT}
-          image: amq-broker-71-openshift
-          imagePullPolicy: Always
-          readinessProbe:
-            exec:
-              command:
-              - "/bin/bash"
-              - "-c"
-              - "/opt/amq/bin/readinessProbe.sh"            
+          - name: AMQ_DATA_DIR
+            value: ${AMQ_DATA_DIR}
+          - name: AMQ_CLUSTERED
+            value: ${AMQ_CLUSTERED}
+          - name: AMQ_REPLICATED
+            value: ${AMQ_REPLICATED} 
+          - name: AMQ_REPLICAS
+            value: ${AMQ_REPLICAS}                                   
+          - name: AMQ_CLUSTER_USER
+            value: ${AMQ_CLUSTER_USER}
+          - name: AMQ_CLUSTER_PASSWORD
+            value: ${AMQ_CLUSTER_PASSWORD}
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+            value: '8888'
+
+          image: "172.30.230.48:5000/openshift/amq-broker-71-openshift:1.0@sha256:8370bab1d0cfffbeb66067fa7ad64e883dffe96d3cb0c1ed0e6212ecd9eeb9f2"         
+          imagePullPolicy: Always            
           name: ${APPLICATION_NAME}-amq
           ports:
           - containerPort: 8161
@@ -153,7 +220,23 @@ objects:
           - containerPort: 61616
             name: artemis
             protocol: TCP
-        terminationGracePeriodSeconds: 60
+          volumeMounts:
+          - name: ${APPLICATION_NAME}-amq-pvol
+            mountPath: ${AMQ_DATA_DIR}
+        serviceAccount: ${APPLICATION_NAME}-service-account
+        serviceAccountName: ${APPLICATION_NAME}-service-account           
+        terminationGracePeriodSeconds: 5
+    volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: ${APPLICATION_NAME}-amq-pvol
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi            
     triggers:
     - imageChangeParams:
         automatic: true
@@ -174,7 +257,7 @@ objects:
   spec:
     to:
       kind: Service
-      name: ${APPLICATION_NAME}-amq-jolokia    
+      name: ${APPLICATION_NAME}-amq-jolokia  
 parameters:
 - description: The name for the application.
   displayName: Application Name
@@ -191,6 +274,11 @@ parameters:
 - description: Address names, separated by commas. These addresses will be automatically created when the broker starts. If left empty, addresses will be still created dynamically.
   displayName: Addresses
   name: AMQ_ADDRESSES
+- description: Size of the volume used by AMQ for persisting messages.
+  displayName: AMQ Volume Size
+  name: VOLUME_CAPACITY
+  value: 1Gi
+  required: true
 - description: User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.
   displayName: AMQ Username
   from: user[a-zA-Z0-9]{3}
@@ -209,6 +297,32 @@ parameters:
   displayName: AMQ Name
   name: AMQ_NAME
   value: broker
+- description: The directory to use for data storage
+  displayName: AMQ Data Directory
+  name: AMQ_DATA_DIR
+  value: /opt/amq/data  
+- description: Clustered
+  displayName: clustered
+  name: AMQ_CLUSTERED
+  value: 'true'
+- description: Number of broker replicas for a cluster
+  displayName: Number of Replicas
+  name: AMQ_REPLICAS
+  value: '2'  
+- description: Replicated
+  displayName: replicated
+  name: AMQ_REPLICATED
+  value: 'false'  
+- description: Clustered user
+  displayName: cluster user
+  from: user[a-zA-Z0-9]{3}
+  generate: expression  
+  name: AMQ_CLUSTER_USER
+- description: Clustered password
+  displayName: cluster password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression  
+  name: AMQ_CLUSTER_PASSWORD
 - description: "Maximum amount of memory which message data may consume (Default: Undefined, half of the system's memory)."
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
@@ -217,4 +331,4 @@ parameters:
   displayName: ImageStream Namespace
   name: IMAGE_STREAM_NAMESPACE
   required: true
-  value: openshift 
+  value: openshift

--- a/templates/amq-broker-71-statefulset-clustered-drain.yaml
+++ b/templates/amq-broker-71-statefulset-clustered-drain.yaml
@@ -11,7 +11,7 @@ metadata:
     openshift.io/display-name: JBoss AMQ Broker 7.1 (Ephemeral, no SSL)
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: messaging,amq,jboss
-    version: 1.4.9
+    version: 1.4.12
   name: amq-broker-71-persistence-with-clustering
 objects:
 - apiVersion: v1
@@ -200,7 +200,7 @@ objects:
                 "image": "amq-broker-71-openshift:1.0",
                 "name": "${APPLICATION_NAME}-amq",
                 
-                "command": ["/bin/sh", "-c", "echo \"Draining data... this takes 10 seconds!\" ; /opt/amq/bin/drain.sh; sleep 1000 ; rm /var/data/test.txt; echo \"Data deleted!\""],               
+                "command": ["/bin/sh", "-c", "echo \"Starting the drainer\" ; /opt/amq/bin/drain.sh; echo \"Drain completed!\""],               
                 "volumeMounts": [
                   {
                     "name": "${APPLICATION_NAME}-amq-pvol",
@@ -266,6 +266,12 @@ objects:
                 fieldPath: metadata.namespace
           - name: OPENSHIFT_DNS_PING_SERVICE_PORT
             value: '8888'
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/amq/bin/readinessProbe.sh"             
           image: "amq-broker-71-openshift:1.0"         
           imagePullPolicy: Always            
           name: ${APPLICATION_NAME}-amq

--- a/templates/amq-broker-71-statefulset-clustered.yaml
+++ b/templates/amq-broker-71-statefulset-clustered.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: amq-broker-71-persistence-with-clustering
+  template: amq-broker-71-statefulset-clustered
   xpaas: 1.4.12
 message: A new messaging service has been created in your project. It will handle the protocol(s) "${AMQ_PROTOCOL}". The username/password for accessing the service is ${AMQ_USER}/${AMQ_PASSWORD}.
 metadata:
@@ -12,13 +12,13 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: messaging,amq,jboss
     version: 1.4.9
-  name: amq-broker-71-persistence-with-clustering
+  name: amq-broker-71-statefulset-clustered
 objects:
 - apiVersion: v1
   kind: Service
   metadata:
     annotations:
-      description: The broker's console and Jolokia port.
+      description: The broker's Jolokia port.
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq-jolokia
@@ -103,116 +103,13 @@ objects:
         port: 8888
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq      
-- apiVersion: apps/v1
+- apiVersion: apps/v1beta1
   kind: StatefulSet
   metadata:
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq
-    annotations:
-      statefulsets.kubernetes.io/drainer-pod-template: |
-        {
-          "metadata": {
-            "labels": {
-              "app": "${APPLICATION_NAME}-amq-drainer"
-            }
-          },
-          "spec": {
-            "serviceAccount": "${APPLICATION_NAME}-service-account",
-            "serviceAccountName": "${APPLICATION_NAME}-service-account",          
-            "terminationGracePeriodSeconds": 5,
-            "containers": [
-              {
-                "env": [
-                  {
-                    "name": "AMQ_USER",
-                    "value": "${AMQ_USER}"
-                  },
-                  {
-                    "name": "AMQ_PASSWORD",
-                    "value": "${AMQ_PASSWORD}"
-                  },
-                  {
-                    "name": "AMQ_ROLE",
-                    "value": "${AMQ_ROLE}"
-                  },
-                  {
-                    "name": "AMQ_NAME",
-                    "value": "${AMQ_NAME}"
-                  },
-                  {
-                    "name": "AMQ_TRANSPORTS",
-                    "value": "${AMQ_PROTOCOL}"
-                  },
-                  {
-                    "name": "AMQ_QUEUES",
-                    "value": "${AMQ_QUEUES}"
-                  },
-                  {
-                    "name": "AMQ_ADDRESSES",
-                    "value": "${AMQ_ADDRESSES}"
-                  },
-                  {
-                    "name": "AMQ_GLOBAL_MAX_SIZE",
-                    "value": "${AMQ_GLOBAL_MAX_SIZE}"
-                  },
-                  {
-                    "name": "AMQ_QUEUE_MEMORY_LIMIT",
-                    "value": "${AMQ_QUEUE_MEMORY_LIMIT}"
-                  },
-                  {
-                    "name": "AMQ_DATA_DIR",
-                    "value": "${AMQ_DATA_DIR}"
-                  },
-                  {
-                    "name": "AMQ_CLUSTERED",
-                    "value": "${AMQ_CLUSTERED}"
-                  },
-                  {
-                    "name": "AMQ_REPLICATED",
-                    "value": "${AMQ_REPLICATED}"
-                  },
-                  {
-                    "name": "AMQ_REPLICAS",
-                    "value": "${AMQ_REPLICAS}"
-                  },
-                  {
-                    "name": "AMQ_CLUSTER_USER",
-                    "value": "${AMQ_CLUSTER_USER}"
-                  },
-                  {
-                    "name": "AMQ_CLUSTER_PASSWORD",
-                    "value": "${AMQ_CLUSTER_PASSWORD}"
-                  },
-                  {
-                    "name": "POD_NAMESPACE",
-                    "valueFrom": {
-                      "fieldRef": {
-                        "fieldPath": "metadata.namespace"
-                      }
-                    }
-                  },
-                  {
-                    "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
-                    "value": "8888"
-                  }                                                             
-                ],              
-                "image": "amq-broker-71-openshift:1.0",
-                "name": "${APPLICATION_NAME}-amq",
-                
-                "command": ["/bin/sh", "-c", "echo \"Draining data... this takes 10 seconds!\" ; /opt/amq/bin/drain.sh; sleep 1000 ; rm /var/data/test.txt; echo \"Data deleted!\""],               
-                "volumeMounts": [
-                  {
-                    "name": "${APPLICATION_NAME}-amq-pvol",
-                    "mountPath": "${AMQ_DATA_DIR}"
-                  }
-                ]
-              }
-            ]
-          }
-        }
   spec:
-    replicas: ${AMQ_REPLICAS}
     selector:
       matchLabels:
         app: ${APPLICATION_NAME}-amq
@@ -253,9 +150,7 @@ objects:
           - name: AMQ_CLUSTERED
             value: ${AMQ_CLUSTERED}
           - name: AMQ_REPLICATED
-            value: ${AMQ_REPLICATED} 
-          - name: AMQ_REPLICAS
-            value: ${AMQ_REPLICAS}                                   
+            value: ${AMQ_REPLICATED}            
           - name: AMQ_CLUSTER_USER
             value: ${AMQ_CLUSTER_USER}
           - name: AMQ_CLUSTER_PASSWORD
@@ -264,10 +159,13 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: OPENSHIFT_DNS_PING_SERVICE_PORT
-            value: '8888'
-          image: "amq-broker-71-openshift:1.0"         
-          imagePullPolicy: Always            
+          image: amq-broker-71-openshift:1.0
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /opt/amq/bin/shutdownHook.sh              
           name: ${APPLICATION_NAME}-amq
           ports:
           - containerPort: 8161
@@ -287,10 +185,10 @@ objects:
             protocol: TCP
           volumeMounts:
           - name: ${APPLICATION_NAME}-amq-pvol
-            mountPath: ${AMQ_DATA_DIR}
+            mountPath: /opt/amq/data
         serviceAccount: ${APPLICATION_NAME}-service-account
         serviceAccountName: ${APPLICATION_NAME}-service-account           
-        terminationGracePeriodSeconds: 5
+        terminationGracePeriodSeconds: 60
     volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -313,16 +211,6 @@ objects:
           namespace: ${IMAGE_STREAM_NAMESPACE}
       type: ImageChange
     - type: ConfigChange
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      application: ${APPLICATION_NAME}
-    name: console
-  spec:
-    to:
-      kind: Service
-      name: ${APPLICATION_NAME}-amq-jolokia  
 parameters:
 - description: The name for the application.
   displayName: Application Name
@@ -362,18 +250,10 @@ parameters:
   displayName: AMQ Name
   name: AMQ_NAME
   value: broker
-- description: The directory to use for data storage
-  displayName: AMQ Data Directory
-  name: AMQ_DATA_DIR
-  value: /opt/amq/data  
 - description: Clustered
   displayName: clustered
   name: AMQ_CLUSTERED
   value: 'true'
-- description: Number of broker replicas for a cluster
-  displayName: Number of Replicas
-  name: AMQ_REPLICAS
-  value: '2'  
 - description: Replicated
   displayName: replicated
   name: AMQ_REPLICATED

--- a/templates/amq-broker-71-statefulset-clustered.yaml
+++ b/templates/amq-broker-71-statefulset-clustered.yaml
@@ -159,6 +159,12 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/amq/bin/readinessProbe.sh"                   
           image: amq-broker-71-openshift:1.0
           imagePullPolicy: Always
           lifecycle:

--- a/templates/amq-broker-71-statefulset.yaml
+++ b/templates/amq-broker-71-statefulset.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: amq-broker-71-basic
-  xpaas: 1.4.12
+  template: amq-broker-71-statefulset
+  xpaas: 1.4.10
 message: A new messaging service has been created in your project. It will handle the protocol(s) "${AMQ_PROTOCOL}". The username/password for accessing the service is ${AMQ_USER}/${AMQ_PASSWORD}.
 metadata:
   annotations:
@@ -18,7 +18,7 @@ objects:
   kind: Service
   metadata:
     annotations:
-      description: The broker's console and Jolokia port.
+      description: The broker's Jolokia port.
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq-jolokia
@@ -87,16 +87,16 @@ objects:
       targetPort: 61616
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
   metadata:
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq
   spec:
-    replicas: 1
     selector:
-      deploymentConfig: ${APPLICATION_NAME}-amq
+      matchLabels:
+        app: ${APPLICATION_NAME}-amq
     strategy:
       rollingParams:
         maxSurge: 0
@@ -106,6 +106,7 @@ objects:
         labels:
           application: ${APPLICATION_NAME}
           deploymentConfig: ${APPLICATION_NAME}-amq
+          app: ${APPLICATION_NAME}-amq
         name: ${APPLICATION_NAME}-amq
       spec:
         containers:
@@ -128,8 +129,15 @@ objects:
             value: ${AMQ_GLOBAL_MAX_SIZE}
           - name: AMQ_QUEUE_MEMORY_LIMIT
             value: ${AMQ_QUEUE_MEMORY_LIMIT}
-          image: amq-broker-71-openshift
+          - name: AMQ_DATA_DIR
+            value: ${AMQ_DATA_DIR}
+          image: amq-broker71-openshift:1.0
           imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /opt/amq/bin/shutdownHook.sh          
           readinessProbe:
             exec:
               command:
@@ -153,7 +161,21 @@ objects:
           - containerPort: 61616
             name: artemis
             protocol: TCP
+          volumeMounts:
+          - name: ${APPLICATION_NAME}-amq-pvol
+            mountPath: /opt/amq/data
         terminationGracePeriodSeconds: 60
+    volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: ${APPLICATION_NAME}-amq-pvol
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi            
     triggers:
     - imageChangeParams:
         automatic: true
@@ -161,20 +183,10 @@ objects:
         - ${APPLICATION_NAME}-amq
         from:
           kind: ImageStreamTag
-          name: amq-broker-71-openshift:1.0
+          name: amq-broker71-openshift:1.0
           namespace: ${IMAGE_STREAM_NAMESPACE}
       type: ImageChange
     - type: ConfigChange
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      application: ${APPLICATION_NAME}
-    name: console
-  spec:
-    to:
-      kind: Service
-      name: ${APPLICATION_NAME}-amq-jolokia    
 parameters:
 - description: The name for the application.
   displayName: Application Name
@@ -191,6 +203,11 @@ parameters:
 - description: Address names, separated by commas. These addresses will be automatically created when the broker starts. If left empty, addresses will be still created dynamically.
   displayName: Addresses
   name: AMQ_ADDRESSES
+- description: Size of the volume used by AMQ for persisting messages.
+  displayName: AMQ Volume Size
+  name: VOLUME_CAPACITY
+  value: 1Gi
+  required: true
 - description: User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.
   displayName: AMQ Username
   from: user[a-zA-Z0-9]{3}


### PR DESCRIPTION
- amq-broker-71-statefulset-clustered-drain.yaml works with a drain controller to drain the messages
- renamed jolokia port, to hide the link in openshift

Signed-off-by: Vanessa Busch <vbusch@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`