### PR TITLE
[CLOUD-2619] Use AMQ_REQUIRE_LOGIN parameter instead of AMQ_ALLOW_ANONYMOUS

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -25,9 +25,9 @@ envs:
     - name: AMQ_ROLE
       example: admin
       description: Role corresponding to AMQ_ROLE
-    - name: AMQ_ALLOW_ANONYMOUS
-      example: true
-      description: Enables anonymous configuration on security
+    - name: AMQ_REQUIRE_LOGIN
+      example: false
+      description: Disables anonymous configuration on security, and will require user / password
     - name: AMQ_NAME
       example: broker
       description: Name of the Broker corresponding to AMQ_NAME

--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -43,13 +43,10 @@ function configureUserAuthentication() {
     echo "Required variable missing: both AMQ_USER and AMQ_PASSWORD are required."
     exit 1
   fi
-  if [ -z "$AMQ_ALLOW_ANONYMOUS" ]; then
-    echo "-z is true"
-  fi
-  if [ -z "$AMQ_ALLOW_ANONYMOUS" -o "$AMQ_ALLOW_ANONYMOUS" = "true" ]; then
-    AMQ_ARGS="$AMQ_ARGS --allow-anonymous"
-  else
+if [ "$AMQ_REQUIRE_LOGIN" = "true" ]; then
     AMQ_ARGS="$AMQ_ARGS --require-login"
+  else
+    AMQ_ARGS="$AMQ_ARGS --allow-anonymous"
   fi
 }
 

--- a/templates/amq-broker-71-basic.yaml
+++ b/templates/amq-broker-71-basic.yaml
@@ -130,8 +130,8 @@ objects:
             value: ${AMQ_ADDRESSES}
           - name: AMQ_GLOBAL_MAX_SIZE
             value: ${AMQ_GLOBAL_MAX_SIZE}
-          - name: AMQ_ALLOW_ANONYMOUS
-            value: ${AMQ_ALLOW_ANONYMOUS}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
           image: amq-broker-71-openshift
           imagePullPolicy: Always
           readinessProbe:
@@ -217,9 +217,9 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login"
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.
   displayName: ImageStream Namespace
   name: IMAGE_STREAM_NAMESPACE

--- a/templates/amq-broker-71-custom.yaml
+++ b/templates/amq-broker-71-custom.yaml
@@ -130,8 +130,8 @@ objects:
             value: ${AMQ_ADDRESSES}
           - name: AMQ_GLOBAL_MAX_SIZE
             value: ${AMQ_GLOBAL_MAX_SIZE}
-          - name: AMQ_ALLOW_ANONYMOUS
-            value: ${AMQ_ALLOW_ANONYMOUS}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
           - name: BROKER_XML
             value: ${BROKER_XML}
           - name: LOGGING_PROPERTIES
@@ -221,9 +221,9 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login."
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.
   displayName: ImageStream Namespace
   name: IMAGE_STREAM_NAMESPACE

--- a/templates/amq-broker-71-persistence-ssl.yaml
+++ b/templates/amq-broker-71-persistence-ssl.yaml
@@ -204,8 +204,8 @@ objects:
             value: ${AMQ_KEYSTORE_PASSWORD}
           - name: AMQ_GLOBAL_MAX_SIZE
             value: ${AMQ_GLOBAL_MAX_SIZE}
-          - name: AMQ_ALLOW_ANONYMOUS
-            value: ${AMQ_ALLOW_ANONYMOUS}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
           - name: AMQ_DATA_DIR
             value: ${AMQ_DATA_DIR}
           image: ${IMAGE}
@@ -348,10 +348,11 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login."
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: Broker Image
+  displayName: Image
   name: IMAGE
   required: true
   value: registry.access.redhat.com/amq-broker-7-tech-preview/amq-broker-71-openshift:1.0

--- a/templates/amq-broker-71-persistence.yaml
+++ b/templates/amq-broker-71-persistence.yaml
@@ -131,8 +131,8 @@ objects:
             value: ${AMQ_ADDRESSES}
           - name: AMQ_GLOBAL_MAX_SIZE
             value: ${AMQ_GLOBAL_MAX_SIZE}
-          - name: AMQ_ALLOW_ANONYMOUS
-            value: ${AMQ_ALLOW_ANONYMOUS}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
           - name: AMQ_DATA_DIR
             value: ${AMQ_DATA_DIR}
           image: ${IMAGE}
@@ -233,10 +233,11 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login."
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: Broker Image
+  displayName: Image
   name: IMAGE
-  required: true
+  required: true  
   value: registry.access.redhat.com/amq-broker-7-tech-preview/amq-broker-71-openshift:1.0

--- a/templates/amq-broker-71-ssl.yaml
+++ b/templates/amq-broker-71-ssl.yaml
@@ -203,8 +203,8 @@ objects:
               value: ${AMQ_KEYSTORE_PASSWORD}
             - name: AMQ_GLOBAL_MAX_SIZE
               value: ${AMQ_GLOBAL_MAX_SIZE}
-            - name: AMQ_ALLOW_ANONYMOUS
-              value: ${AMQ_ALLOW_ANONYMOUS}
+            - name: AMQ_REQUIRE_LOGIN
+              value: ${AMQ_REQUIRE_LOGIN}
             image: amq-broker-71-openshift
             imagePullPolicy: Always
             readinessProbe:
@@ -333,9 +333,9 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login"
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.
   displayName: ImageStream Namespace
   name: IMAGE_STREAM_NAMESPACE

--- a/templates/amq-broker-71-statefulset-clustered.yaml
+++ b/templates/amq-broker-71-statefulset-clustered.yaml
@@ -148,8 +148,8 @@ objects:
             value: ${AMQ_ADDRESSES}
           - name: AMQ_GLOBAL_MAX_SIZE
             value: ${AMQ_GLOBAL_MAX_SIZE}
-          - name: AMQ_ALLOW_ANONYMOUS
-            value: ${AMQ_ALLOW_ANONYMOUS}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
           - name: AMQ_DATA_DIR
             value: ${AMQ_DATA_DIR}
           - name: AMQ_CLUSTERED
@@ -277,14 +277,15 @@ parameters:
   displayName: AMQ Global Max Size
   name: AMQ_GLOBAL_MAX_SIZE
   value: 100 gb
-- description: "Determines whether or not the broker will allow anonymous access."
-  displayName: AMQ Allow Anonymous
-  name: AMQ_ALLOW_ANONYMOUS
+- description: "Determines whether or not the broker will allow anonymous access, or require login"
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
 - description: The directory to use for data storage
   displayName: AMQ Data Directory
   name: AMQ_DATA_DIR
   value: /opt/amq/data
 - description: Broker Image
+  displayName: Image
   name: IMAGE
   required: true
   value: registry.access.redhat.com/amq-broker-7-tech-preview/amq-broker-71-openshift:1.0


### PR DESCRIPTION
Change the templates and launch script use AMQ_REQUIRE_LOGIN. By default require-login will be set to false, and the templates have it set to false. In order to require-login, they will need to set AMQ_REQUIRE_LOGIN=true.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`