### PR TITLE
ENTMQBR-1648 Don't hardcode openshift.DNS_PING service name

### DIFF
--- a/modules/amq-launch/added/jgroups-ping.xml
+++ b/modules/amq-launch/added/jgroups-ping.xml
@@ -32,7 +32,7 @@
          oob_thread_pool.queue_max_size="100"
          oob_thread_pool.rejection_policy="discard"/>
 
-<openshift.DNS_PING timeout="3000" serviceName="ping" />
+<openshift.DNS_PING timeout="3000" serviceName="${APPLICATION_NAME}-${PING_SVC_NAME}" />
                          
     <MERGE3  min_interval="10000"
              max_interval="30000"/>

--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -159,6 +159,22 @@ function modifyDiscovery() {
   discoverygroup="${discoverygroup}       </discovery-group>	"
   sed -i -ne "/<discovery-groups>/ {p; i $discoverygroup" -e ":a; n; /<\/discovery-groups>/ {p; b}; ba}; p" ${instanceDir}/etc/broker.xml	
 
+  #generate jgroups-ping.xml
+  echo "Generating jgroups-ping.xml, current dir is: $PWD, AMQHOME: $AMQ_HOME"
+
+  if [ -z "${PING_SVC_NAME+x}" ]; then
+    echo "PING_SERVICE is not set"
+    PING_SVC_NAME=ping
+  fi
+
+  if [ -z "${APPLICATION_NAME+x}" ]; then
+    echo "APPLICATION_NAME is not set"
+    sed -i -e "s/\${APPLICATION_NAME}-\${PING_SVC_NAME}/${PING_SVC_NAME}/" $AMQ_HOME/conf/jgroups-ping.xml
+  else
+    echo "APPLICATION_NAME is set"
+    sed -i -e "s/\${APPLICATION_NAME}-\${PING_SVC_NAME}/${APPLICATION_NAME}-${PING_SVC_NAME}/" $AMQ_HOME/conf/jgroups-ping.xml
+  fi
+  
   broadcastgroup=""		
   broadcastgroup="${broadcastgroup}       <broadcast-group name=\"my-broadcast-group\">"
   broadcastgroup="${broadcastgroup}          <jgroups-file>jgroups-ping.xml</jgroups-file>"

--- a/templates/amq-broker-73-persistence-clustered-ssl.yaml
+++ b/templates/amq-broker-73-persistence-clustered-ssl.yaml
@@ -124,7 +124,7 @@ objects:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
     labels:
       application: ${APPLICATION_NAME}
-    name: ping
+    name: ${APPLICATION_NAME}-${PING_SVC_NAME}
   spec:
     clusterIP: None  
     ports:
@@ -154,6 +154,14 @@ objects:
             "containers": [
               {
                 "env": [
+                  {
+                    "name": "APPLICATION_NAME",
+                    "value": "${APPLICATION_NAME}"
+                  },
+                  {
+                    "name": "PING_SVC_NAME",
+                    "value": "${PING_SVC_NAME}"
+                  },
                   {
                     "name": "AMQ_EXTRA_ARGS",
                     "value": "--no-autotune"
@@ -266,6 +274,10 @@ objects:
       spec:
         containers:
         - env:
+          - name: APPLICATION_NAME
+            value: ${APPLICATION_NAME}
+          - name: PING_SVC_NAME
+            value: ${PING_SVC_NAME}
           - name: AMQ_USER
             value: ${AMQ_USER}
           - name: AMQ_PASSWORD
@@ -382,6 +394,11 @@ parameters:
   name: APPLICATION_NAME
   required: true
   value: broker
+- description: The name for JGroups DNS_PING service.
+  displayName: DNS Ping Service Name
+  name: PING_SVC_NAME
+  required: true
+  value: ping
 - description: 'Protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp`, `mqtt` and `hornetq`.'
   displayName: AMQ Protocols
   name: AMQ_PROTOCOL

--- a/templates/amq-broker-73-persistence-clustered.yaml
+++ b/templates/amq-broker-73-persistence-clustered.yaml
@@ -108,7 +108,7 @@ objects:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
     labels:
       application: ${APPLICATION_NAME}
-    name: ping
+    name: ${APPLICATION_NAME}-${PING_SVC_NAME}
   spec:
     clusterIP: None  
     ports:
@@ -138,6 +138,14 @@ objects:
             "containers": [
               {
                 "env": [
+                  {
+                    "name": "APPLICATION_NAME",
+                    "value": "${APPLICATION_NAME}"
+                  },
+                  {
+                    "name": "PING_SVC_NAME",
+                    "value": "${PING_SVC_NAME}"
+                  },
                   {
                     "name": "AMQ_EXTRA_ARGS",
                     "value": "--no-autotune"
@@ -250,6 +258,10 @@ objects:
       spec:
         containers:
         - env:
+          - name: APPLICATION_NAME
+            value: ${APPLICATION_NAME}
+          - name: PING_SVC_NAME
+            value: ${PING_SVC_NAME}
           - name: AMQ_USER
             value: ${AMQ_USER}
           - name: AMQ_PASSWORD
@@ -337,6 +349,11 @@ parameters:
   name: APPLICATION_NAME
   required: true
   value: broker
+- description: The name for JGroups DNS_PING service.
+  displayName: DNS Ping Service Name
+  name: PING_SVC_NAME
+  required: true
+  value: ping
 - description: 'Protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp`, `mqtt` and `hornetq`.'
   displayName: AMQ Protocols
   name: AMQ_PROTOCOL


### PR DESCRIPTION
Now the service name takes the form of
${APPLICATION_NAME}-${PING_SERVICE_NAME}

If both APPLICATION_NAME and PING_SERVICE_NAME are absent the
DNS_PING service name will be default to 'ping' (that's the
original value). If only APPLICATION_NAME is absent, the service
name is the value of PING_SERVICE_NAME (without prefixed with
the dash).

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`