### PR TITLE
ENTMQBR-2638 Add support for netty-tcnative usage in the broker image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -128,6 +128,8 @@ modules:
 packages:
       install:
           - PyYAML
+          - openssl
+          - apr
 
 run:
       user: 185

--- a/modules/amq-launch/install.sh
+++ b/modules/amq-launch/install.sh
@@ -15,6 +15,7 @@ mkdir -p ${DEST}/conf/
 
 cp -p ${SOURCES_DIR}/openshift-ping-common-$VERSION.jar \
   ${SOURCES_DIR}/openshift-ping-dns-$VERSION.jar \
+  ${SOURCES_DIR}/netty-tcnative-2.0.25.Final-redhat-00001-linux-x86_64.jar \
   ${DEST}/lib
 
 cp -p $ADDED_DIR/jgroups-ping.xml \

--- a/modules/amq-launch/module.yaml
+++ b/modules/amq-launch/module.yaml
@@ -6,7 +6,13 @@ execute:
     - script: install.sh    
     
 artifacts:
-- path: openshift-ping-common-1.2.1.Final-redhat-1.jar
+- name: openshift-ping-common
+  target: openshift-ping-common-1.2.1.Final-redhat-1.jar
   md5: 7a6db2d84d9c6326363522f97f2d0f05
-- path: openshift-ping-dns-1.2.1.Final-redhat-1.jar
+- name: openshift-ping-dns
+  target: openshift-ping-dns-1.2.1.Final-redhat-1.jar
   md5: fbd94724882e9ad41d1c4db52875b8d4
+- name: netty-tcnative
+  target: netty-tcnative-2.0.25.Final-redhat-00001-linux-x86_64.jar
+  md5: cbb10a867c4c56d94c059fd466d2f960
+


### PR DESCRIPTION
This is the second commit to add missing tcnative native jar.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`