### PR TITLE
[ENTMQBR-3670] Adding 7.7 image with openj9 on z

### DIFF
--- a/content_sets_ubi8.yml
+++ b/content_sets_ubi8.yml
@@ -1,0 +1,3 @@
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms

--- a/modules/amq-launch/added/drain.sh
+++ b/modules/amq-launch/added/drain.sh
@@ -34,7 +34,7 @@ ENDPOINTS=$(curl -s -X GET -G -k -H "${endpointsAuth}" ${endpointsUrl}"endpoints
 echo $ENDPOINTS
 count=0
 while [ 1 ]; do
-  ip=$(echo $ENDPOINTS | python -c "import sys, json; print json.load(sys.stdin)['subsets'][0]['addresses'][${count}]['ip']")
+  ip=$(echo $ENDPOINTS | python2 -c "import sys, json; print json.load(sys.stdin)['subsets'][0]['addresses'][${count}]['ip']")
   if [ $? -ne 0 ]; then
     echo "Can't find ip to scale down to tried ${count} ips"
     exit

--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -17,6 +17,16 @@ JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 #GC Option conflicts with the one already configured.
 echo "Removing provided -XX:+UseParallelOldGC in favour of artemis.profile provided option"
 JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-XX:+UseParallelOldGC/ /")
+PLATFORM=`uname -m`
+echo "Platform is ${PLATFORM}"
+if [ "${PLATFORM}" = "s390x" ] ; then
+  #GC Option found to be a problem on s390x               
+  echo "Removing -XX:+UseG1GC as per recommendation to use default GC"        
+  JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-XX:+UseG1GC/ /")
+  #JDK11 related warnings removal
+  echo "Adding -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true as per ENTMQBR-1932"
+  JAVA_OPTS="-Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true ${JAVA_OPTS}"
+fi
 JAVA_OPTS="-Djava.net.preferIPv4Stack=true ${JAVA_OPTS}"
 
 function sslPartial() {

--- a/modules/amq-launch/added/readinessProbe.sh
+++ b/modules/amq-launch/added/readinessProbe.sh
@@ -92,7 +92,7 @@ while : ; do
     PROBE_MESSAGE="No configuration file located: ${CONFIG_FILE}"
 
     if [ -f "${CONFIG_FILE}" ] ; then
-        python -c "$EVALUATE_SCRIPT" >"${OUTPUT}" 2>"${ERROR}"
+        python2 -c "$EVALUATE_SCRIPT" >"${OUTPUT}" 2>"${ERROR}"
 
         CONNECT_RESULT=$?
         if [ true = "${DEBUG_SCRIPT}" ] ; then

--- a/modules/amq-launch/install.sh
+++ b/modules/amq-launch/install.sh
@@ -16,6 +16,7 @@ mkdir -p ${DEST}/conf/
 cp -p ${SOURCES_DIR}/openshift-ping-common-$VERSION.jar \
   ${SOURCES_DIR}/openshift-ping-dns-$VERSION.jar \
   ${SOURCES_DIR}/netty-tcnative-2.0.29.Final-redhat-00001-linux-x86_64-fedora.jar \
+  ${SOURCES_DIR}/netty-tcnative-2.0.29.Final-redhat-00001-linux-s390_64-fedora.jar \
   ${DEST}/lib
 
 cp -p $ADDED_DIR/jgroups-ping.xml \

--- a/modules/amq-launch/module.yaml
+++ b/modules/amq-launch/module.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: amq.broker77.launch
-version: '1.0'
+version: '1.2'
 execute:
     - script: install.sh    
     
@@ -12,7 +12,10 @@ artifacts:
 - name: openshift-ping-dns
   target: openshift-ping-dns-1.2.6.Final-redhat-1.jar
   md5: 59925c951d904b7734c2d10dc41a6515
-- name: netty-tcnative
+- name: netty-tcnative-x86_64
   target: netty-tcnative-2.0.29.Final-redhat-00001-linux-x86_64-fedora.jar
   md5: 48b03c0f95ab093e70eb15c1f29fdaea
+- name: netty-tcnative-s390_64
+  target: netty-tcnative-2.0.29.Final-redhat-00001-linux-s390_64-fedora.jar
+  md5: 21859c2640a23ce470dd642a3ed4c71b 
 

--- a/overrides-j911-ga.yaml
+++ b/overrides-j911-ga.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+
+from: "registry-proxy.engineering.redhat.com/rh-osbs/amq-broker-7-amq-broker-77-openj9-11-rhel8:7.7-2"
+name: &name "amq-broker-7/amq-broker-77-openshift-openj9-11-rhel8"
+version: &version "7.7"
+
+labels:
+- name: "com.redhat.component"
+  value: "amq-broker-openshift-openj9-11-rhel8-container"
+
+envs:
+- name: "JBOSS_IMAGE_NAME"
+  value: *name
+- name: "JBOSS_IMAGE_VERSION"
+  value: *version
+
+modules:
+      repositories:
+          - path: modules
+          - name: cct_module
+            git:
+                 url: https://github.com/artemiscloud/cct_module.git
+                 ref: 0.38.0-amq
+      install:
+          - name: dynamic-resources
+          - name: os-amq-s2i
+          - name: os-java-run
+          - name: openshift-passwd
+          - name: os-logging
+          - name: os-amq-permissions
+          - name: os-java-jolokia
+          - name: amq.broker77.jolokia.access
+          - name: amq.broker77.launch
+          - name: amq.broker77.s2i
+          - name: amq.custom.config   
+
+packages:
+    content_sets_file: content_sets_ubi8.yml
+    install:
+        - openssl
+        - apr
+
+osbs:
+  configuration:
+    container:
+      platforms:
+        only:
+          - s390x
+  repository:
+    name: containers/amq-broker
+    branch: amq-broker-7.7-openshift-openj9-11-rhel8


### PR DESCRIPTION
This is to add 7.7 support on z with openjdk 11 + openj9 on ubi 8 base image.
https://issues.redhat.com/browse/ENTMQBR-3670

Signed-off-by: Lei Zhang lzhan@redhat.com

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`