### PR TITLE
[ENTMQBR-5341] Add back AMQ_ENABLE_METRICS_PLUGIN env var support to container image

### DIFF
--- a/modules/amq-launch/added/launch.sh
+++ b/modules/amq-launch/added/launch.sh
@@ -284,6 +284,21 @@ function injectMetricsPlugin() {
   sed -i "s/^\([[:blank:]]*\)<\\/core>/\1\1<metrics> <plugin class-name=\"org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin\"\\/> <\\/metrics>\\n\1<\\/core>/" $instanceDir/etc/broker.xml
 }
 
+function checkBeforeRun() {
+  instanceDir=$1
+  if [ "$AMQ_ENABLE_METRICS_PLUGIN" = "true" ]; then
+    pluginStr="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin"
+    grep -q "$pluginStr" ${instanceDir}/etc/broker.xml
+    result=$?
+    if [[ $result == 0 ]]; then
+      echo "The Prometheus plugin already configured."
+    else
+      echo "Need to inject Prometheus plugin"
+      injectMetricsPlugin ${instanceDir}
+    fi
+  fi
+}
+
 function selectDelim {
   content="$1"
   DELIM=""
@@ -687,6 +702,7 @@ function runServer() {
     fi
     if [ "$1" != "nostart" ]; then
       echo "Running Broker in ${instanceDir}"
+      checkBeforeRun ${instanceDir}
       exec ${instanceDir}/bin/artemis run
     fi
   fi


### PR DESCRIPTION
Users used to enable metrics plugin using this env var directly on broker openshift image by modifying the statefulset while being deployed via broker operator. Now as we moved the configuration into init container, this method no longer works. In future, we will add direct support for enabling metrics plugin from CR level with operator.

https://issues.redhat.com/browse/ENTMQBR-5341

Signed-off-by: Rafiur Rashid rrashid@redhat.com

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`